### PR TITLE
Add support for custom filenames and resolve collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ vim.api.nvim_set_keymap('n','<C-i>', "<cmd>lua require('markdown-image-paste').p
  - [ ] check if data in clipboard is image before pasting
  - [ ] check if file is markdown file
  - [ ] check if image in clipboard already has been saved to file before ( reuse old files )
- - [ ] file name collision detection and resolution
- - [ ] promt user for custom file name
+ - [x] file name collision detection and resolution
+ - [x] prompt user for custom file name
  - [ ] support for other rich text formats (fx latex, RTF)

--- a/lua/markdown-image-paste/init.lua
+++ b/lua/markdown-image-paste/init.lua
@@ -32,7 +32,7 @@ function M.getfilename()
         end
 
         -- Check if the generated filename is unique, and exit the loop if it is.
-        if not M.file_exists(M.relative_path(filename)) then
+        if not M.file_exists(M.relative_path(filename)) and filename ~= ".png" then
             break -- Unique filename found, exit the loop.
         elseif M.custom_filename then
             -- Inform the user if the chosen custom filename already exists.

--- a/lua/markdown-image-paste/init.lua
+++ b/lua/markdown-image-paste/init.lua
@@ -2,15 +2,48 @@ local M = {}
 
 M.dirname = "images"
 M.filename = "img"
+M.custom_filename = false
 
 function M.setup(config)
     M.dirname = config.dirname
     M.filename = config.filename
+    M.custom_filename = config.custom_filename
+end
+
+function M.relative_path(filename)
+    return M.dirname .. "/" .. filename
+end
+
+function M.file_exists(filename)
+   local f = io.open(filename, "r")
+   return f ~= nil and io.close(f)
+end
+
+function M.getfilename()
+    local filename
+    math.randomseed(os.time())
+    while true do
+        if M.custom_filename then
+            -- Prompt the user for a filename if custom filename is enabled.
+            filename = vim.fn.input("Filename (without extension): "..M.dirname.."/") .. '.png'
+        else
+            -- Generate a random filename.
+            filename = M.filename .. math.random(1, 9999) .. '.png'
+        end
+
+        -- Check if the generated filename is unique, and exit the loop if it is.
+        if not M.file_exists(M.relative_path(filename)) then
+            break -- Unique filename found, exit the loop.
+        elseif M.custom_filename then
+            -- Inform the user if the chosen custom filename already exists.
+            vim.print("\nFile already exists. Please try a different name.")
+        end
+    end
+    return filename
 end
 
 function M.createImageFile()
-    math.randomseed(os.time())
-    local filename = M.filename..math.random(1,9999)..'.png'
+    local filename = M.getfilename()
     local filepath = vim.fn.expand('%:h')..'/'..M.dirname..'/'.. filename
     image = io.open(filepath,"w")
     for key,imgpart in pairs(vim.fn.getreg('+',1,1)) do


### PR DESCRIPTION
This PR adds support for custom filenames by exposing the config bool value, `custom_filename`.
If `custom_filename` is set to true, the user will be prompted for a filename when they call `M.pasteImage()`.
Also, when a filename is determined (either from user input or random name) and it collides with an already existing file, a new filename will be determined (either from user input or random name depending on user configuration).